### PR TITLE
 Refactor Disconnect button to use event instead of writing to input_text

### DIFF
--- a/v2g_liberty.py
+++ b/v2g_liberty.py
@@ -94,12 +94,6 @@ class V2GLibertyApp(hass.Hass, WallboxModbusMixin):
         # ToDo: Remove all schedules?
         self.notify_user("Charger disconnected charger.")
 
-    #TODO: combine with same function in other modules??
-    def notify_user(self, message: str):
-        """ Utility function to send notifications to the user via HA.
-        """
-        self.notify(message, title="V2G Liberty")
-
     def handle_calendar_change(self, *args, **fnc_kwargs):
         self.log("Calendar update detected.")
         self.decide_whether_to_ask_for_new_schedule()

--- a/v2g_liberty.py
+++ b/v2g_liberty.py
@@ -85,7 +85,7 @@ class V2GLibertyApp(hass.Hass, WallboxModbusMixin):
 
 
     def disconnect_charger(self, *args, **kwargs):
-        """ Function te disconnect the charger.
+        """ Function to disconnect the charger.
         Reacts to button in UI that fires DISCONNECT_CHARGER event.
         """
         self.log("************* Disconnect charger requested. *************")


### PR DESCRIPTION
 Refactor Disconnect button to use event instead of writing to input_text #35

 The button now writes "Disconnect" to the input_text.chargeschedule. A rather clumsy way of getting the event in v2g_liberty.py
Replace this with the proper way of throwing a named event that is then caught in the AppDaemon module.

This also requires a change in the disconnect script in the v2g_liberty_package.yaml