### PR TITLE
Send null values instead of -1 values

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,11 +436,11 @@ set_fm_data:
   fm_soc_entity_address: !secret fm_soc_entity_address
 
   fm_chargepower_resolution_in_minutes: !secret fm_quasar_event_resolution_in_minutes
+  car_min_soc_in_percent: !secret car_min_soc_in_percent
 
   wallbox_host: !secret wallbox_host
   wallbox_port: !secret wallbox_port
   wallbox_modbus_registers: !include /config/appdaemon/apps/v2g-liberty/app_config/wallbox_modbus_registers.yaml
-
 ```
 
 ## Configure HA to use v2g-liberty

--- a/set_fm_data.py
+++ b/set_fm_data.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 import json
 import math
 import requests
-from typing import List
+from typing import List, Union
 import appdaemon.plugins.hass.hassapi as hass
 from wallbox_client import WallboxModbusMixin
 from util_functions import time_round, time_ceil
@@ -69,9 +69,9 @@ class SetFMdata(hass.Hass, WallboxModbusMixin):
     current_availability_since: datetime
     availability_readings: List[float]
 
-    # State of Charge (SoC) of connected car battery. If not connected set to -1.
-    soc_readings: List[int]
-    connected_car_soc: int
+    # State of Charge (SoC) of connected car battery. If not connected set to None.
+    soc_readings: List[Union[int, None]]
+    connected_car_soc: Union[int, None]
 
     
     def initialize(self):
@@ -89,7 +89,7 @@ class SetFMdata(hass.Hass, WallboxModbusMixin):
         self.listen_state(self.handle_charge_power_change, "sensor.charger_real_charging_power", attribute="all")
 
         # SoC related
-        self.connected_car_soc = -1
+        self.connected_car_soc = None
         self.soc_readings = []
 
         # Availability related
@@ -127,12 +127,12 @@ class SetFMdata(hass.Hass, WallboxModbusMixin):
         if isinstance(reported_soc, str):
             if not reported_soc.isnumeric():
                 # Sometimes the charger returns "Unknown" or "Undefined" or "Unavailable"
-                self.connected_car_soc = -1
+                self.connected_car_soc = None
                 return
             reported_soc = int(round(float(reported_soc), 0))
 
         if reported_soc == 0:
-            self.connected_car_soc = -1
+            self.connected_car_soc = None
             return
 
         self.log(f"Processed reported SoC, self.connected_car_soc is now set to: {reported_soc}%.")

--- a/set_fm_data.py
+++ b/set_fm_data.py
@@ -398,8 +398,12 @@ class SetFMdata(hass.Hass, WallboxModbusMixin):
 
         charge_mode = self.get_state("input_select.charge_mode")
         # Forced charging in progress if SoC is below 20%
-        if self.is_car_connected() and charge_mode == "Automatic" and self.connected_car_soc >= 20:
-            return True
+        if self.is_car_connected() and charge_mode == "Automatic":
+            if self.connected_car_soc is None:
+                # SoC is unknown, assume availability
+                return True
+            else:
+                return self.connected_car_soc >= 20
         else:
             return False
 

--- a/set_fm_data.py
+++ b/set_fm_data.py
@@ -397,15 +397,14 @@ class SetFMdata(hass.Hass, WallboxModbusMixin):
         # How to take an upcoming calendar item in to account?
 
         charge_mode = self.get_state("input_select.charge_mode")
-        # Forced charging in progress if SoC is below 20%
+        # Forced charging in progress if SoC is below the minimum SoC setting
         if self.is_car_connected() and charge_mode == "Automatic":
             if self.connected_car_soc is None:
                 # SoC is unknown, assume availability
                 return True
             else:
-                return self.connected_car_soc >= 20
-        else:
-            return False
+                return self.connected_car_soc >= self.CAR_MIN_SOC_IN_PERCENT
+        return False
 
 
 


### PR DESCRIPTION
Send null values instead of -1 values, which avoids recording -1 values in FlexMeasures, while still correctly spacing the data sent.

This is possible since https://github.com/FlexMeasures/flexmeasures/pull/549.

@ArdJonker, can you verify that this works as expected in production?

(In case you are wondering, the Python `None` values are changed into JavaScript `null` values in the call to `requests.post()`, which turns the sent message - a `dict` - into a JSON string.)