### PR TITLE
Fix broken flexmeasures client

### DIFF
--- a/flexmeasures_client.py
+++ b/flexmeasures_client.py
@@ -82,11 +82,12 @@ class FlexMeasuresClient(hass.Hass):
         ---------
         https://flexmeasures.readthedocs.io/en/latest/api/introduction.html#deprecation-and-sunset
         """
-        warnings = res.headers.get_all("Deprecation") + res.headers.get_all("Sunset")
+        self.log(res.headers)
+        warnings = res.headers.get("Deprecation") or res.headers.get("Sunset")
         if warnings:
-            message = f"Your request to {url} returned {'a warning' if len(warnings) == 1 else f'{len(warnings)} warnings'}."
+            message = f"Your request to {url} returned a warning."
             # Go through the response headers in their given order
-            for header, content in res.headers:
+            for header, content in res.headers.items():
                 if header == "Deprecation":
                     message += f"\nDeprecation: {content}."
                 elif header == "Sunset":

--- a/flexmeasures_client.py
+++ b/flexmeasures_client.py
@@ -208,10 +208,10 @@ class FlexMeasuresClient(hass.Hass):
             target_datetime = time_round(isodate.parse_datetime(target_datetime), resolution).isoformat()
 
         message = {
+            "start": soc_datetime,
             "flex-model": {
                 "soc-at-start": current_soc_kwh,
                 "soc-unit": "kWh",
-                "start": soc_datetime,
                 "soc-targets": [
                     {
                         "value": target,

--- a/flexmeasures_client.py
+++ b/flexmeasures_client.py
@@ -1,11 +1,10 @@
 from datetime import datetime, timedelta
+import json
 import pytz
 import re
 import requests
-import time
 import isodate
-from typing import Optional
-from util_functions import time_mod, time_round
+from util_functions import time_round
 
 import appdaemon.plugins.hass.hassapi as hass
 

--- a/flexmeasures_client.py
+++ b/flexmeasures_client.py
@@ -82,7 +82,6 @@ class FlexMeasuresClient(hass.Hass):
         ---------
         https://flexmeasures.readthedocs.io/en/latest/api/introduction.html#deprecation-and-sunset
         """
-        self.log(res.headers)
         warnings = res.headers.get("Deprecation") or res.headers.get("Sunset")
         if warnings:
             message = f"Your request to {url} returned a warning."


### PR DESCRIPTION
- [x] Add missing `import json`
- [x] Remove unused imports
- [x] Fix use of response headers (HA uses `async_upnp_client.utils.CaseInsensitiveDict` rather than `werkzeug.datastructures.MultiDict`)
- [x] Move 'start' field out of 'flex-model' field