### PR TITLE
Allow more control over optimization context

### DIFF
--- a/app_config/v2g_liberty_package.yaml
+++ b/app_config/v2g_liberty_package.yaml
@@ -44,6 +44,8 @@ input_select:
     options:
       - Price
       - Emissions
+      - ANWB Energie
+      - Tibber
     initial: Price
 
 input_boolean:


### PR DESCRIPTION
Allow more control over optimization context by introducing the Tibber and ANWB Energie optimization modes, with distinct price sensors for consumption and production.

@ArdJonker please test, and also consider moving the `DEFAULT_FM_OPTIMISATION_MODES` into the `v2g_liberty_package.yaml`. That should make it more convenient to add optimisation modes for additional suppliers.