### PR TITLE
#149 Warn user charging is possibly blocked by Wallbox 

### DIFF
--- a/app_config/v2g_liberty_dashboard.yaml
+++ b/app_config/v2g_liberty_dashboard.yaml
@@ -45,6 +45,29 @@ views:
 
           - type: conditional
             conditions:
+              - entity: input_text.charger_state
+                state: "Connected: controlled by Wallbox App"
+              - entity: input_boolean.chargemodeoff
+                state: "off"
+            card:
+              type: markdown
+              card_mod:
+                style: |
+                  ha-card {
+                    border-top: none;
+                    border-top-left-radius: 0;
+                    border-top-right-radius: 0;
+                    margin-top: -28px;
+                  }
+              content: >-
+                <ha-alert alert-type="warning" title="The charger is controlled by Wallbox App">V2G Liberty might not be able to charge</ha-alert>
+
+                It seem that there is a charge time-schedule set in the Wallbox app. V2G&nbsp;Liberty probably cannot control the charger now.
+
+                Remove the time-schedule for charging from the Wallbox app for automatic charging via V2G Liberty.
+
+          - type: conditional
+            conditions:
               - entity: sensor.charger_charger_state
                 state: "0"
               - entity: sensor.charger_locked

--- a/app_config/v2g_liberty_package.yaml
+++ b/app_config/v2g_liberty_package.yaml
@@ -172,7 +172,6 @@ input_text:
     mode: text
     min: 0
 
-
   # Helper, set by V2G Liberty.py based upon setting utility in secrets.
   # Used only for setting text in dashboard.
   utility_display_name:
@@ -543,7 +542,7 @@ automation:
                 target:
                   entity_id: input_text.charger_state
                 data:
-                  value: "Connected: waiting for next schedule"
+                  value: "Connected: controlled by Wallbox App"
           - conditions:
               - condition: state
                 entity_id: sensor.charger_charger_state

--- a/app_config/wallbox_modbus_registers.yaml
+++ b/app_config/wallbox_modbus_registers.yaml
@@ -65,6 +65,10 @@ charging_state: &charging 1
 # Connected and waiting for car demand; sometimes shortly goes to this status when action = start
 waiting_state: &waiting 2
 
+# Connected and waiting for next schedule; this occurs when a charging is scheduled via the Wallbox app.
+# As we control the charger we override this setting
+waiting_for_schedule_state: &waiting_for_schedule 3
+
 # Connected and paused by user; goes to this status when action = stop or when gun is connected and auto start = disabled
 paused_state: &paused 4
 
@@ -80,7 +84,6 @@ in_queue_state: &in_queue 10
 discharging_state: &discharging 11
 
 # Unused charger statuses (for now)
-# 3: Connected: waiting for next schedule
 # 5: Connected: end of schedule
 # 6: Disconnected locked
 # 8: Connected: In queue by Power Sharing
@@ -93,11 +96,13 @@ charging_states:
 connected_states:
   - *in_queue
   - *waiting
+  - *waiting_for_schedule
   - *paused
   - *charging
   - *discharging
 idle_states:
   - *waiting
+  - *waiting_for_schedule
   - *paused
 
 # Error codes

--- a/constants.py
+++ b/constants.py
@@ -1,7 +1,7 @@
 ### V2G Liberty constants ###
 
-# Date 2023-11-27 Pull requests 145, 148 and
-V2G_LIBERTY_VERSION = "0.1.1"
+# Date 2023-11-30 Pull request 149
+V2G_LIBERTY_VERSION = "0.1.2"
 
 # USER PREFRENCE
 # See remark for charger constants


### PR DESCRIPTION
A charge time-schedule has been set in the Wallbox app and this in some cases blocks V2G Liberty from taking control and charging.

The state has been renamed from "Connected: Waiting for next schedule" to "Connected: controlled by Wallbox App"
A message is added in the dashboard.yaml, triggered by this state.
The the state has been added to the idle_ and connected_states in the wallbox registers.yaml so that V2G Liberty at least tries to take control even thought it might not always work (i don't know exactly why).
This also influences the "is_connected" state in the wallbox_client.py and so the availability in the set_fm_data.py. Here might be a small mis-match in the availability as sometimes charging works, sometimes it does not.