### PR TITLE
#151 Make stats card responsive: move to end of page on mobile.

### DIFF
--- a/app_config/table_style.yaml
+++ b/app_config/table_style.yaml
@@ -1,0 +1,35 @@
+ha-markdown$: |
+  h3 {
+    font-weight: normal;
+    color: #797979;
+    font-size: 90%;
+    padding-bottom: 0;
+  }
+  h4 {
+    font-weigth: normal;
+    font-size: 150%;
+    line-height: 90%;
+    margin-top: -5px;
+    margin-bottom: 2px;
+  }
+  table {
+    width: 100%;
+    max-width: 100%;
+  }
+  tbody td, tfoot td {
+    font-weight: bold;
+  }
+  th {
+    text-align: left;
+    vertical-align: top;
+    font-weight: normal;
+  }
+  td {
+    text-align: right;
+  }
+  thead th, thead td {
+    border-bottom: 1px solid #cccccc;
+  }
+  tfoot th, tfoot td {
+    border-top: 1px solid #cccccc;
+  }

--- a/app_config/v2g_liberty_dashboard.yaml
+++ b/app_config/v2g_liberty_dashboard.yaml
@@ -3,10 +3,10 @@ views:
   - path: default_view
     title: Main
     icon: mdi:car-electric
-    layout:
-      width: 300
-      max_cols: 10
-    badges: []
+    #layout:
+    #min-width: 350
+    #max_cols: a
+    #badges: []
     cards:
       - type: vertical-stack
         title: Charger
@@ -140,71 +140,15 @@ views:
                   margin-bottom: 48px;
                 }
 
-          - type: markdown
-            content: >-
-              <h3>Last 7 days (approximations)</h3>
-              <h4>Costs {{ '€ %.2f'|format(float(states("input_number.total_charging_cost_last_7_days"))/float(states("input_number.net_energy_last_7_days"))) }}/kWh</h4>
-              <table><thead>
-              <tr>
-                <th></th>
-                <th>duration</th>
-                <td>Emissions (kg CO₂)</td>
-                <td>Energy (kWh)</td>
-              </tr></thead>
-              <tbody><tr>
-                <th>Charge</th>
-                <th>{{states("input_text.total_charge_time_last_7_days")}}</th>
-                <td>{{ '%.1f'|format((states("input_number.total_emissions_last_7_days")) | round(1)) }}</td>
-                <td>{{ (states("input_number.total_charged_energy_last_7_days")) | int }}</td>
-              </tr><tr>
-                <th>Discharge</th>
-                <th>{{states("input_text.total_discharge_time_last_7_days")}}</th>
-                <td>{{ '%.1f'|format((states("input_number.total_saved_emissions_last_7_days")) | round(1)) }}</td>
-                <td>{{ (states("input_number.total_discharged_energy_last_7_days")) | int }}</td>
-              </tr></tbody>
-              <tfoot><tr>
-                <th>Net results</th>
-                <th></th>
-                <td>{{ '%.1f'|format((states("input_number.net_emissions_last_7_days")) | round(1)) }}</td>
-                <td>{{ (states("input_number.net_energy_last_7_days")) | int }}</td>
-              </tr></tfoot></table>
-            card_mod:
-              style:
-                ha-markdown$: |
-                  h3 {
-                    font-weight: normal;
-                    color: #797979;
-                    font-size: 90%;
-                    padding-bottom: 0;
-                  }
-                  h4 {
-                    font-weigth: normal;
-                    font-size: 150%;
-                    line-height: 90%;
-                    margin-top: -5px;
-                    margin-bottom: 2px;
-                  }
-                  table {
-                    width: 100%;
-                    max-width: 100%;
-                  }
-                  tbody td, tfoot td {
-                    font-weight: bold;
-                  }
-                  th {
-                    text-align: left;
-                    vertical-align: top;
-                    font-weight: normal;
-                  }
-                  td {
-                    text-align: right;
-                  }
-                  thead th, thead td {
-                    border-bottom: 1px solid #cccccc;
-                  }
-                  tfoot th, tfoot td {
-                    border-top: 1px solid #cccccc;
-                  }
+          - type: conditional
+            conditions:
+              - condition: screen
+                media_query: "(min-width: 1024px)"
+            card:
+              type: markdown
+              content: !include v2g_liberty_ui_module_stats.yaml
+              card_mod:
+                style: !include table_style.yaml
 
       - type: vertical-stack
         title: Connected car
@@ -471,6 +415,16 @@ views:
                   color: #6f6f6f;
                   display: block;
                 }
+
+          - type: conditional
+            conditions:
+              - condition: screen
+                media_query: "(max-width: 1024px)"
+            card:
+              type: markdown
+              content: !include v2g_liberty_ui_module_stats.yaml
+              card_mod:
+                style: !include table_style.yaml
 
           - type: markdown
             content: >-

--- a/app_config/v2g_liberty_ui_module_stats.yaml
+++ b/app_config/v2g_liberty_ui_module_stats.yaml
@@ -1,0 +1,26 @@
+<h3>Last 7 days (approximations)</h3>
+<h4>Costs {{ '€ %.2f'|format(float(states("input_number.total_charging_cost_last_7_days"))/float(states("input_number.net_energy_last_7_days"))) }}/kWh</h4>
+<table><thead>
+<tr>
+<th></th>
+<th>duration</th>
+<td>Emissions (kg CO₂)</td>
+<td>Energy (kWh)</td>
+</tr></thead>
+<tbody><tr>
+<th>Charge</th>
+<th>{{states("input_text.total_charge_time_last_7_days")}}</th>
+<td>{{ '%.1f'|format((states("input_number.total_emissions_last_7_days")) | round(1)) }}</td>
+<td>{{ (states("input_number.total_charged_energy_last_7_days")) | int }}</td>
+</tr><tr>
+<th>Discharge</th>
+<th>{{states("input_text.total_discharge_time_last_7_days")}}</th>
+<td>{{ '%.1f'|format((states("input_number.total_saved_emissions_last_7_days")) | round(1)) }}</td>
+<td>{{ (states("input_number.total_discharged_energy_last_7_days")) | int }}</td>
+</tr></tbody>
+<tfoot><tr>
+<th>Net results</th>
+<th></th>
+<td>{{ '%.1f'|format((states("input_number.net_emissions_last_7_days")) | round(1)) }}</td>
+<td>{{ (states("input_number.net_energy_last_7_days")) | int }}</td>
+</tr></tfoot></table>

--- a/app_config/wallbox_modbus_registers.yaml
+++ b/app_config/wallbox_modbus_registers.yaml
@@ -65,7 +65,7 @@ charging_state: &charging 1
 # Connected and waiting for car demand; sometimes shortly goes to this status when action = start
 waiting_state: &waiting 2
 
-# Connected and waiting for next schedule; this occurs when a charging is scheduled via the Wallbox app.
+# Connected and waiting for next schedule; this occurs when a charging session is scheduled via the Wallbox app.
 # As we control the charger we override this setting
 waiting_for_schedule_state: &waiting_for_schedule 3
 

--- a/constants.py
+++ b/constants.py
@@ -1,7 +1,7 @@
 ### V2G Liberty constants ###
 
-# Date 2023-11-30 Pull request 149
-V2G_LIBERTY_VERSION = "0.1.2"
+# Date 2023-11-30 Pull request 151
+V2G_LIBERTY_VERSION = "0.1.3"
 
 # USER PREFRENCE
 # See remark for charger constants


### PR DESCRIPTION
For this that content of the stats card has been moved to a separate yaml that is included via a markup card.
This strongly simplifies the original dashboard .yaml as it is added twice under different conditions.

And a tiny text change that was hanging for #149